### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/src/main/scala/loaders/CifarLoader.scala
+++ b/src/main/scala/loaders/CifarLoader.scala
@@ -63,8 +63,8 @@ class CifarLoader(path: String) {
   }
 
   def readBatch(file: File, batch: Int, images: Array[Array[Byte]], labels: Array[Int], perm: Vector[Int]) {
-    val buffer = new Array[Byte](1 + size);
-    val inputStream = new FileInputStream(file);
+    val buffer = new Array[Byte](1 + size)
+    val inputStream = new FileInputStream(file)
 
     var i = 0
     var nRead = inputStream.read(buffer)

--- a/src/test/scala/apps/CallbackBenchmarkSpec.scala
+++ b/src/test/scala/apps/CallbackBenchmarkSpec.scala
@@ -67,7 +67,7 @@ class CallbackBenchmarkSpec extends FlatSpec {
     ()
   }
   val byteImageCallback = makeByteImageCallback(byteImageMinibatch, Some(preprocessing))
-  val data = new Memory(channels * fullWidth * fullHeight * trainBatchSize * dtypeSize);
+  val data = new Memory(channels * fullWidth * fullHeight * trainBatchSize * dtypeSize)
 
   log("before byte image callback")
   byteImageCallback.invoke(data, trainBatchSize, 3, new Pointer(0))
@@ -80,7 +80,7 @@ class CallbackBenchmarkSpec extends FlatSpec {
         for (j <- 0 to batchSize - 1) {
           preprocessing.get(minibatch(j), buffer)
           val dtypeSize = 4
-          data.write(j * 227 * 227 * 3 * dtypeSize, buffer, 0, 227 * 227 * 3);
+          data.write(j * 227 * 227 * 3 * dtypeSize, buffer, 0, 227 * 227 * 3)
         }
       }
     }

--- a/src/test/scala/libs/CifarSpec.scala
+++ b/src/test/scala/libs/CifarSpec.scala
@@ -22,7 +22,7 @@ class CifarSpec extends FlatSpec {
     val solver = ProtoLoader.loadSolverPrototxt(sparkNetHome + "/caffe/examples/cifar10/cifar10_full_java_solver.prototxt")
 
     val byteArr = solver.toByteArray()
-    val ptr = new Memory(byteArr.length);
+    val ptr = new Memory(byteArr.length)
     ptr.write(0, byteArr, 0, byteArr.length)
     caffeLib.load_solver_from_protobuf(state, ptr, byteArr.length)
 
@@ -49,7 +49,7 @@ class CifarSpec extends FlatSpec {
             }
           }
          }
-      };
+      }
     }
 
     def makeLabelCallback(labels: Array[Int]) : CaffeLibrary.java_callback_t =  {
@@ -65,7 +65,7 @@ class CifarSpec extends FlatSpec {
             }
           }
         }
-      };
+      }
     }
 
     val loadTrainImageFn = makeImageCallback(loader.trainImages)

--- a/src/test/scala/libs/LayerSpec.scala
+++ b/src/test/scala/libs/LayerSpec.scala
@@ -4,8 +4,8 @@ import java.io._
 import caffe._
 import caffe.Caffe._
 
-import com.sun.jna.Pointer;
-import com.sun.jna.Memory;
+import com.sun.jna.Pointer
+import com.sun.jna.Memory
 
 class LayerSpec extends FlatSpec {
   "Layer definition" should "should be loadable" in {
@@ -33,7 +33,7 @@ class LayerSpec extends FlatSpec {
     val lenetState = caffeLib.create_state()
 
     var byteArr = netParam.toByteArray()
-    var ptr = new Memory(byteArr.length);
+    var ptr = new Memory(byteArr.length)
     ptr.write(0, byteArr, 0, byteArr.length)
     caffeLib.load_net_from_protobuf(lenetState, ptr, byteArr.length)
 
@@ -44,7 +44,7 @@ class LayerSpec extends FlatSpec {
     val state = caffeLib.create_state()
 
     byteArr = solverParameter.toByteArray()
-    ptr = new Memory(byteArr.length);
+    ptr = new Memory(byteArr.length)
     ptr.write(0, byteArr, 0, byteArr.length)
     caffeLib.load_solver_from_protobuf(state, ptr, byteArr.length)
 	}


### PR DESCRIPTION
Noticed a bunch of java-like semicolons in the scala code.  This is a trivial PR to tidy up a bit.