### PR TITLE
Remove unnecessary return statements from scala

### DIFF
--- a/src/main/scala/libs/Layers.scala
+++ b/src/main/scala/libs/Layers.scala
@@ -35,7 +35,7 @@ object RDDLayer {
       }
       result.addInclude(netState)
     }
-    return result.build()
+    result.build()
   }
 }
 
@@ -51,7 +51,7 @@ object ConvolutionLayer {
     result.addAllTop(List(name).asJava)
     result.addAllBottom(bottom.asJava)
     result.setConvolutionParam(layerParam)
-    return result.build()
+    result.build()
   }
 }
 
@@ -81,7 +81,7 @@ object PoolingLayer {
     result.addAllTop(List(name).asJava)
     result.addAllBottom(bottom.asJava)
     result.setPoolingParam(layerParam)
-    return result.build()
+    result.build()
   }
 }
 
@@ -95,7 +95,7 @@ object InnerProductLayer {
     result.addAllTop(List(name).asJava)
     result.addAllBottom(bottom.asJava)
     result.setInnerProductParam(layerParam)
-    return result.build()
+    result.build()
   }
 }
 
@@ -108,7 +108,7 @@ object ReLULayer {
     result.addAllTop(List(name).asJava)
     result.addAllBottom(bottom.asJava)
     result.setReluParam(layerParam)
-    return result.build()
+    result.build()
   }
 }
 
@@ -123,7 +123,7 @@ object SoftmaxWithLoss {
     result.addAllBottom(bottom.asJava)
     result.setLossParam(lossParam)
     result.setSoftmaxParam(softmaxParam)
-    return result.build()
+    result.build()
   }
 }
 
@@ -132,6 +132,6 @@ object NetParam {
     val result = NetParameter.newBuilder()
     result.setName(name)
     result.addAllLayer(layers.toList.asJava)
-    return result.build()
+    result.build()
   }
 }

--- a/src/main/scala/libs/MinibatchSampler.scala
+++ b/src/main/scala/libs/MinibatchSampler.scala
@@ -36,24 +36,24 @@ class MinibatchSampler(minibatchIt: Iterator[(Array[ByteImage], Array[Int])], to
   def nextImageMinibatch(): Array[ByteImage] = {
     if (currMinibatchImages.isEmpty) {
       nextMinibatch()
-      return currMinibatchImages.get
+      currMinibatchImages.get
     } else {
       val images = currMinibatchImages.get
       currMinibatchImages = None
       currMinibatchLabels = None
-      return images
+      images
     }
   }
 
   def nextLabelMinibatch(): Array[Int] = {
     if (currMinibatchLabels.isEmpty) {
       nextMinibatch()
-      return currMinibatchLabels.get
+      currMinibatchLabels.get
     } else {
       val labels = currMinibatchLabels.get
       currMinibatchImages = None
       currMinibatchLabels = None
-      return labels
+      labels
     }
   }
 

--- a/src/main/scala/libs/NDArray.scala
+++ b/src/main/scala/libs/NDArray.scala
@@ -5,15 +5,15 @@ class NDArray private(val javaArray: JavaNDArray) extends java.io.Serializable {
   val shape = javaArray.shape
 
   def subarray(lowerOffsets: Array[Int], upperOffsets: Array[Int]): NDArray = {
-    return new NDArray(javaArray.subArray(lowerOffsets, upperOffsets))
+    new NDArray(javaArray.subArray(lowerOffsets, upperOffsets))
   }
 
   def slice(axis: Int, index: Int): NDArray = {
-    return new NDArray(javaArray.slice(axis, index))
+    new NDArray(javaArray.slice(axis, index))
   }
 
   def get(indices: Array[Int]): Float = {
-    return javaArray.get(indices:_*)
+    javaArray.get(indices:_*)
   }
 
   def set(indices: Array[Int], value: Float) = {
@@ -25,11 +25,11 @@ class NDArray private(val javaArray: JavaNDArray) extends java.io.Serializable {
   }
 
   def toFlat(): Array[Float] = {
-    return javaArray.toFlat()
+    javaArray.toFlat()
   }
 
   def getBuffer(): Array[Float] = {
-    return javaArray.getBuffer()
+    javaArray.getBuffer()
   }
 
   def add(that: NDArray) = {
@@ -55,6 +55,6 @@ object NDArray {
   def plus(v1: NDArray, v2: NDArray): NDArray = {
     val v = new NDArray(new JavaNDArray(v1.toFlat(), v1.shape:_*))
     v.add(v2)
-    return v
+    v
   }
 }

--- a/src/main/scala/libs/Net.scala
+++ b/src/main/scala/libs/Net.scala
@@ -42,7 +42,7 @@ object WeightCollection extends java.io.Serializable {
         newWeights(layerNames(i)) += NDArray.plus(wc1.allWeights(layerNames(i))(j), wc2.allWeights(layerNames(i))(j))
       }
     }
-    return new WeightCollection(newWeights, layerNames)
+    new WeightCollection(newWeights, layerNames)
   }
 }
 
@@ -114,8 +114,8 @@ class CaffeNet(state: Pointer, caffeLib: CaffeLibrary) extends Net {
       testScores(i) = caffeLib.get_test_score(state, i) // for accuracy layers, this returns the average accuracy over a minibatch
     }
     print("testScores = " + testScores.deep.toString + "\n")
-    return testScores
-    //return Array(0)
+    testScores
+    //Array(0)
   }
 
   def forward() = {
@@ -167,7 +167,7 @@ class CaffeNet(state: Pointer, caffeLib: CaffeLibrary) extends Net {
       }
       allWeights += (layerNames(i) -> weightList)
     }
-    return new WeightCollection(allWeights, layerNames)
+    new WeightCollection(allWeights, layerNames)
   }
 
   def getData(): Map[String, NDArray] = {
@@ -187,11 +187,11 @@ class CaffeNet(state: Pointer, caffeLib: CaffeLibrary) extends Net {
       }
       allData += (name -> NDArray(data, shape))
     }
-    return allData
+    allData
   }
 
   private def makeImageCallback(minibatchSampler: MinibatchSampler, preprocessing: Option[(ByteImage, Array[Float]) => Unit] = None): CaffeLibrary.java_callback_t = {
-    return new CaffeLibrary.java_callback_t() {
+    new CaffeLibrary.java_callback_t() {
       def invoke(data: Pointer, batchSize: Int, numDims: Int, shape: Pointer) {
         val currentImageBatch = minibatchSampler.nextImageMinibatch()
         assert(currentImageBatch.length == batchSize)
@@ -220,7 +220,7 @@ class CaffeNet(state: Pointer, caffeLib: CaffeLibrary) extends Net {
   }
 
   def makeLabelCallback(minibatchSampler: MinibatchSampler): CaffeLibrary.java_callback_t = {
-    return new CaffeLibrary.java_callback_t {
+    new CaffeLibrary.java_callback_t {
       def invoke(data: Pointer, batchSize: Int, numDims: Int, shape: Pointer) {
         val currentLabelBatch = minibatchSampler.nextLabelMinibatch()
         assert(currentLabelBatch.length == batchSize)
@@ -245,7 +245,7 @@ class CaffeNet(state: Pointer, caffeLib: CaffeLibrary) extends Net {
     for (k <- 0 to numAxes - 1) {
       shape(k) = caffeLib.get_axis_shape(blob, k)
     }
-    return shape
+    shape
   }
 }
 
@@ -257,6 +257,6 @@ object CaffeNet {
     val ptr = new Memory(byteArr.length)
     ptr.write(0, byteArr, 0, byteArr.length)
     caffeLib.load_solver_from_protobuf(state, ptr, byteArr.length)
-    return new CaffeNet(state, caffeLib)
+    new CaffeNet(state, caffeLib)
   }
 }

--- a/src/main/scala/libs/ProtoLoader.scala
+++ b/src/main/scala/libs/ProtoLoader.scala
@@ -14,7 +14,7 @@ object ProtoLoader {
     var data = caffeLib.get_prototxt_data(state)
     var bytes = data.getByteArray(0, len)
     caffeLib.destroy_state(state)
-    return SolverParameter.parseFrom(bytes)
+    SolverParameter.parseFrom(bytes)
   }
 
   def loadNetPrototxt(filename: String): NetParameter = {
@@ -25,7 +25,7 @@ object ProtoLoader {
     var data = caffeLib.get_prototxt_data(state)
     var bytes = data.getByteArray(0, len)
     caffeLib.destroy_state(state)
-    return NetParameter.parseFrom(bytes)
+    NetParameter.parseFrom(bytes)
   }
 
   def loadSolverPrototxtWithNet(solverFilename: String, netParameter: NetParameter, snapshotPath: Option[String]) : SolverParameter = {
@@ -39,12 +39,12 @@ object ProtoLoader {
     }
     solverBuilder.clearNet()
     solverBuilder.setNetParam(netParameter)
-    return solverBuilder.build()
+    solverBuilder.build()
   }
 
   def loadSolverWithNetPrototxt(solverFilename: String, netFilename: String, snapshotPath: Option[String]) : SolverParameter = {
     val netParameter = loadNetPrototxt(netFilename)
-    return loadSolverPrototxtWithNet(solverFilename, netParameter, snapshotPath)
+    loadSolverPrototxtWithNet(solverFilename, netParameter, snapshotPath)
   }
 
   def replaceDataLayers(netParameter: NetParameter, trainBatchSize: Int, testBatchSize: Int, numChannels: Int, height: Int, width: Int): NetParameter = {
@@ -53,6 +53,6 @@ object ProtoLoader {
     netBuilder.setLayer(1, RDDLayer("label", shape=List(trainBatchSize, 1), Some(Include.Train)))
     netBuilder.addLayer(0, RDDLayer("data", shape=List(testBatchSize, numChannels, height, width), Some(Include.Test)))
     netBuilder.addLayer(1, RDDLayer("label", shape=List(testBatchSize, 1), Some(Include.Test)))
-    return netBuilder.build()
+    netBuilder.build()
   }
 }

--- a/src/main/scala/libs/WorkerStore.scala
+++ b/src/main/scala/libs/WorkerStore.scala
@@ -11,7 +11,7 @@ class WorkerStore() {
   }
 
   def getNet(name: String): CaffeNet = {
-    return nets(name)
+    nets(name)
   }
 
   def setLib(library: CaffeLibrary) = {
@@ -20,6 +20,6 @@ class WorkerStore() {
 
   def getLib(): CaffeLibrary = {
     assert(!caffeLib.isEmpty)
-    return caffeLib.get
+    caffeLib.get
   }
 }

--- a/src/main/scala/loaders/ImageNetLoader.scala
+++ b/src/main/scala/loaders/ImageNetLoader.scala
@@ -50,7 +50,7 @@ class ImageNetLoader(bucket: String) extends java.io.Serializable {
       labelsMap(filename) = label.toInt
       line = labelsReader.readLine()
     }
-    return labelsMap
+    labelsMap
   }
 
   def loadImagesFromTar(filePathsRDD: RDD[URI], broadcastMap: Broadcast[Map[String, Int]]): RDD[(Array[Byte], Int)] = {

--- a/src/main/scala/preprocessing/ComputeMean.scala
+++ b/src/main/scala/preprocessing/ComputeMean.scala
@@ -34,7 +34,7 @@ object ComputeMean {
       imageSum(j) /= numData
       j += 1
     }
-    return NDArray(imageSum, shape)
+    NDArray(imageSum, shape)
   }
 
   def computeMeanFromMinibatches(minibatchRDD: RDD[(Array[ByteImage], Array[Int])], shape: Array[Int], numData: Int): NDArray = {
@@ -72,7 +72,7 @@ object ComputeMean {
       imageSum(j) /= numData
       j += 1
     }
-    return NDArray(imageSum, shape)
+    NDArray(imageSum, shape)
   }
 
   def writeMeanToBinaryProto(caffeLib: CaffeLibrary, meanImage: NDArray, filename: String) = {

--- a/src/test/scala/apps/CallbackBenchmarkSpec.scala
+++ b/src/test/scala/apps/CallbackBenchmarkSpec.scala
@@ -74,7 +74,7 @@ class CallbackBenchmarkSpec extends FlatSpec {
   log("before full callback")
 
   private def makeByteImageCallback(minibatch: Array[ByteImage], preprocessing: Option[(ByteImage, Array[Float]) => Unit] = None): CaffeLibrary.java_callback_t = {
-    return new CaffeLibrary.java_callback_t() {
+    new CaffeLibrary.java_callback_t() {
       def invoke(data: Pointer, batchSize: Int, numDims: Int, shape: Pointer) {
         var buffer = new Array[Float](227 * 227 * 3 * batchSize)
         for (j <- 0 to batchSize - 1) {

--- a/src/test/scala/libs/CifarFeaturizationSpec.scala
+++ b/src/test/scala/libs/CifarFeaturizationSpec.scala
@@ -32,7 +32,7 @@ class CifarFeaturizationSpec extends FlatSpec {
     val intSize = caffeLib.get_int_size()
 
     def makeImageCallback(images: Array[Array[Byte]]) : CaffeLibrary.java_callback_t = {
-      return new CaffeLibrary.java_callback_t() {
+      new CaffeLibrary.java_callback_t() {
         var currImage = 0
         def invoke(data: Pointer, batch_size: Int, num_dims: Int, shape: Pointer) {
           var size = 1
@@ -55,7 +55,7 @@ class CifarFeaturizationSpec extends FlatSpec {
     }
 
     def makeLabelCallback(labels: Array[Int]) : CaffeLibrary.java_callback_t =  {
-      return new CaffeLibrary.java_callback_t() {
+      new CaffeLibrary.java_callback_t() {
         var currImage = 0
         def invoke(data: Pointer, batch_size: Int, num_dims: Int, shape: Pointer) {
           for(j <- 0 to batch_size - 1) {

--- a/src/test/scala/libs/CifarSpec.scala
+++ b/src/test/scala/libs/CifarSpec.scala
@@ -30,7 +30,7 @@ class CifarSpec extends FlatSpec {
     val intSize = caffeLib.get_int_size()
 
     def makeImageCallback(images: Array[Array[Byte]]) : CaffeLibrary.java_callback_t = {
-      return new CaffeLibrary.java_callback_t() {
+      new CaffeLibrary.java_callback_t() {
         var currImage = 0
         def invoke(data: Pointer, batch_size: Int, num_dims: Int, shape: Pointer) {
           var size = 1
@@ -53,7 +53,7 @@ class CifarSpec extends FlatSpec {
     }
 
     def makeLabelCallback(labels: Array[Int]) : CaffeLibrary.java_callback_t =  {
-      return new CaffeLibrary.java_callback_t() {
+      new CaffeLibrary.java_callback_t() {
         var currImage = 0
         def invoke(data: Pointer, batch_size: Int, num_dims: Int, shape: Pointer) {
           for(j <- 0 to batch_size-1) {


### PR DESCRIPTION
In scala it is not idiomatic to include "return" statements. This is a trivial cleanup.